### PR TITLE
feat: Add goToOverride support to Popup, Search, Bookmarks

### DIFF
--- a/demos/consistent-focus.html
+++ b/demos/consistent-focus.html
@@ -5,9 +5,10 @@
 
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no"> 
+  <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no">
   <title>Consistent Focus</title>
 
   <link id="dark-style" rel="stylesheet" href="https://js.arcgis.com/4.29/esri/themes/dark/main.css" />
@@ -18,212 +19,219 @@
   <script type="module" src="https://js.arcgis.com/calcite-components/2.6.0/calcite.esm.js"></script>
 
   <style>
-      #mapEl {
-        height: 100vh;
-        width: calc(100vw - 49px);
-        padding-left: 49px;
-      }
-      body.calcite-mode-dark {
-        --calcite-ui-focus-color: var(--calcite-color-brand);
-        --calcite-color-brand: #d67229;
-        --calcite-color-brand-hover: #D67229BF;
-        --calcite-color-brand-press:#D67229E6;
-      }
-      body {
-        --calcite-ui-focus-color: var(--calcite-color-brand);
-        --calcite-color-brand: #000;
-        --calcite-color-brand-hover: #000000BF;
-        --calcite-color-brand-press: #000000E6;
-      }
+    #mapEl {
+      height: 100vh;
+      width: calc(100vw - 49px);
+      padding-left: 49px;
+    }
+
+    body.calcite-mode-dark {
+      --calcite-ui-focus-color: var(--calcite-color-brand);
+      --calcite-color-brand: #d67229;
+      --calcite-color-brand-hover: #D67229BF;
+      --calcite-color-brand-press: #D67229E6;
+    }
+
+    body {
+      --calcite-ui-focus-color: var(--calcite-color-brand);
+      --calcite-color-brand: #000;
+      --calcite-color-brand-hover: #000000BF;
+      --calcite-color-brand-press: #000000E6;
+    }
   </style>
 </head>
 
-  <body class="calcite-mode-dark">
-    <calcite-shell content-behind>
-      <calcite-navigation slot="header" id="nav">
-        <calcite-navigation-logo
-          icon="accessibility"
-          slot="logo"
-          heading="Consistent Focus"
-          description="Esri Developer Summit 2024"
-        ></calcite-navigation-logo>
-          <calcite-action-pad layout="horizontal" expand-disabled slot="content-end">
-            <calcite-action id="toggle-mode" text="Toggle mode" icon="brightness"></calcite-action>
-          </calcite-action-pad>
-          <calcite-tooltip placement="bottom" reference-element="toggle-mode" slot="content-end">Toggle mode</calcite-tooltip>
-      </calcite-navigation>
+<body class="calcite-mode-dark">
+  <calcite-shell content-behind>
+    <calcite-navigation slot="header" id="nav">
+      <calcite-navigation-logo icon="accessibility" slot="logo" heading="Consistent Focus"
+        description="Esri Developer Summit 2024"></calcite-navigation-logo>
+      <calcite-action-pad layout="horizontal" expand-disabled slot="content-end">
+        <calcite-action id="toggle-mode" text="Toggle mode" icon="brightness"></calcite-action>
+      </calcite-action-pad>
+      <calcite-tooltip placement="bottom" reference-element="toggle-mode" slot="content-end">Toggle
+        mode</calcite-tooltip>
+    </calcite-navigation>
 
-      <calcite-shell-panel slot="panel-start" display-mode="float">
-        <calcite-action-bar slot="action-bar">
-          <calcite-action data-action-id="layer-effects" icon="effects" text="Layer effects"></calcite-action>
-        </calcite-action-bar>
-        <!-- Layer effects -->
-        <calcite-panel heading="Layer effects" height-scale="l" data-panel-id="layer-effects" closable closed>
-            <!-- Bloom effect -->
-            <calcite-block open heading="Bloom" description="Apply a neon-like glow">
-              <!-- Bloom enabled -->
-              <calcite-block-section id="bloom-effect" open text="Apply bloom effect" toggle-display="switch">
-              <!-- Intensity -->
-              <calcite-label for="bloom-intensity">Bloom intensity</calcite-label>
-              <calcite-slider id="bloom-intensity" value="1.5" min="0" max="10" step="0.5" label-ticks ticks="2"></calcite-slider>
-              <!-- Radius-->
-              <calcite-label for="bloom-radius">Bloom radius</calcite-label>
-              <calcite-slider id="bloom-radius" value="0.5" min="0" max="1" step="0.5" label-ticks ticks="0.25"></calcite-slider>
-              <!-- Threshold -->
-              <calcite-label for="bloom-threshold">Bloom threshold</calcite-label>
-              <calcite-slider id="bloom-threshold" value="0.1" min="0" max="0.5" step="0.1" label-ticks ticks="0.25"></calcite-slider>
-              </calcite-block-section>
-          </calcite-block>
-          <!-- Drop shadow effect -->
-          <calcite-block open heading="Drop shadow" description="Apply a drop shadow">
-            <!-- Shadow enabled -->
-            <calcite-block-section id="shadow-effect" text="Apply drop shadow effect" toggle-display="switch">
+    <calcite-shell-panel slot="panel-start" display-mode="float">
+      <calcite-action-bar slot="action-bar">
+        <calcite-action data-action-id="layer-effects" icon="effects" text="Layer effects"></calcite-action>
+      </calcite-action-bar>
+      <!-- Layer effects -->
+      <calcite-panel heading="Layer effects" height-scale="l" data-panel-id="layer-effects" closable closed>
+        <!-- Bloom effect -->
+        <calcite-block open heading="Bloom" description="Apply a neon-like glow">
+          <!-- Bloom enabled -->
+          <calcite-block-section id="bloom-effect" open text="Apply bloom effect" toggle-display="switch">
+            <!-- Intensity -->
+            <calcite-label for="bloom-intensity">Bloom intensity</calcite-label>
+            <calcite-slider id="bloom-intensity" value="1.5" min="0" max="10" step="0.5" label-ticks
+              ticks="2"></calcite-slider>
+            <!-- Radius-->
+            <calcite-label for="bloom-radius">Bloom radius</calcite-label>
+            <calcite-slider id="bloom-radius" value="0.5" min="0" max="1" step="0.5" label-ticks
+              ticks="0.25"></calcite-slider>
+            <!-- Threshold -->
+            <calcite-label for="bloom-threshold">Bloom threshold</calcite-label>
+            <calcite-slider id="bloom-threshold" value="0.1" min="0" max="0.5" step="0.1" label-ticks
+              ticks="0.25"></calcite-slider>
+          </calcite-block-section>
+        </calcite-block>
+        <!-- Drop shadow effect -->
+        <calcite-block open heading="Drop shadow" description="Apply a drop shadow">
+          <!-- Shadow enabled -->
+          <calcite-block-section id="shadow-effect" text="Apply drop shadow effect" toggle-display="switch">
             <!-- Shadow length -->
             <calcite-label for="shadow-length">Shadow length</calcite-label>
-            <calcite-slider id="shadow-length" value="3" min="0" max="4" step="1" label-ticks ticks="1"></calcite-slider>
+            <calcite-slider id="shadow-length" value="3" min="0" max="4" step="1" label-ticks
+              ticks="1"></calcite-slider>
             <!-- Shadow depth-->
             <calcite-label for="shadow-depth">Shadow depth</calcite-label>
             <calcite-slider id="shadow-depth" value="1" min="0" max="4" step="1" label-ticks ticks="1"></calcite-slider>
             <!-- Shadow outline -->
             <calcite-label for="shadow-outline">Shadow outline</calcite-label>
-            <calcite-slider id="shadow-outline" value="3" min="0" max="4" step="1" label-ticks ticks="1"></calcite-slider>
+            <calcite-slider id="shadow-outline" value="3" min="0" max="4" step="1" label-ticks
+              ticks="1"></calcite-slider>
           </calcite-block-section>
-      </calcite-block> 
+        </calcite-block>
+      </calcite-panel>
+    </calcite-shell-panel>
+
+    <calcite-panel>
+      <arcgis-map item-id="c2a3444863f2466aaad9efa6e65063e1" id="mapEl">
+        <arcgis-legend position="bottom-right"></arcgis-legend>
+        <arcgis-expand mode="floating" position="top-right">
+          <arcgis-search></arcgis-search>
+        </arcgis-expand>
+      </arcgis-map>
     </calcite-panel>
-  </calcite-shell-panel>
 
-  <calcite-panel>
-    <arcgis-map item-id="c2a3444863f2466aaad9efa6e65063e1" id="mapEl">
-      <arcgis-legend legend-style="classic" position="bottom-right"></arcgis-legend>
-    </arcgis-map>
-  </calcite-panel>
+  </calcite-shell>
 
-</calcite-shell>
+</body>
 
-  </body>
+<script>
+  const mapEl = document.getElementById("mapEl");
+  const actionBarEl = document.querySelector("calcite-action-bar");
 
-  <script>
-    const mapEl = document.getElementById("mapEl");
-    const actionBarEl = document.querySelector("calcite-action-bar");
+  let activeWidget;
 
-    let activeWidget;
+  // Mode
+  let mode = "dark";
 
-    // Mode
-    let mode = "dark";
+  const toggleModeEl = document.getElementById("toggle-mode");
+  const darkModeCss = document.getElementById("dark-style");
+  const lightModeCss = document.getElementById("light-style");
 
-    const toggleModeEl = document.getElementById("toggle-mode");
-    const darkModeCss = document.getElementById("dark-style");
-    const lightModeCss = document.getElementById("light-style");
+  // Layer effects
+  const effectBlockSectionEl = document.getElementById("bloom-effect");
+  const shadowBlockSectionEl = document.getElementById("shadow-effect");
 
-    // Layer effects
-    const effectBlockSectionEl = document.getElementById("bloom-effect");
-    const shadowBlockSectionEl = document.getElementById("shadow-effect");
+  let bloomIntensity = 1.5;
+  let bloomRadius = 0.5;
+  let bloomThreshold = 0.1;
 
-    let bloomIntensity = 1.5;
-    let bloomRadius = 0.5;
-    let bloomThreshold = 0.1;
+  let shadowLength = 3;
+  let shadowDepth = 1;
+  let shadowOutline = 3;
 
-    let shadowLength = 3;
-    let shadowDepth = 1;
-    let shadowOutline = 3;
+  // Toggle mode
+  toggleModeEl.addEventListener("click", () => {
+    mode = mode === "dark" ? "light" : "dark";
+    const isDarkMode = mode === "dark";
+    darkModeCss.disabled = !darkModeCss.disabled;
+    lightModeCss.disabled = !lightModeCss.disabled;
+    const widgets = document.getElementsByClassName("esri-ui");
+    for (let i = 0; i < widgets.length; i++) {
+      widgets.item(i).classList.toggle("calcite-mode-dark");
+      widgets.item(i).classList.toggle("calcite-mode-light");
+    }
+    mapEl.basemap = isDarkMode ? "dark-gray" : "gray";
+    toggleModeEl.icon = isDarkMode ? "moon" : "brightness";
+    document.body.className = isDarkMode ? "calcite-mode-dark" : undefined;
+  });
 
-    // Toggle mode
-    toggleModeEl.addEventListener("click", () => {
-      mode = mode === "dark" ? "light" : "dark";
-      const isDarkMode = mode === "dark";
-      darkModeCss.disabled = !darkModeCss.disabled;
-      lightModeCss.disabled = !lightModeCss.disabled;
-      const widgets = document.getElementsByClassName("esri-ui");
-      for (let i = 0; i < widgets.length; i++) {
-        widgets.item(i).classList.toggle("calcite-mode-dark");
-        widgets.item(i).classList.toggle("calcite-mode-light");
-      }
-      mapEl.basemap = isDarkMode ? "dark-gray" : "gray";
-      toggleModeEl.icon = isDarkMode ? "moon" : "brightness";
-      document.body.className = isDarkMode ? "calcite-mode-dark" : undefined;
-    });
-
-    // Bloom effects
-    effectBlockSectionEl.addEventListener("calciteBlockSectionToggle", (evt) => {
-      if (evt.target.open) {
-        shadowBlockSectionEl.open = false;
-        updateBloom(bloomIntensity, bloomRadius, bloomThreshold);
-      } else {
-        updateBloom(0, 0, 0);
-      }
-    });
-
-    // Drop shadow effects
-    shadowBlockSectionEl.addEventListener("calciteBlockSectionToggle", (evt) => {
-      if (evt.target.open) {
-        effectBlockSectionEl.open = false;
-        updateShadow(shadowLength, shadowDepth, shadowOutline);
-      } else {
-        updateShadow(0, 0, 0);
-      }
-    });
-
-    // Layer effect values
-    const sliderEls = document.querySelectorAll("calcite-slider");
-    sliderEls?.forEach((sliderEl) => {
-      sliderEl.addEventListener("calciteSliderInput", () => {
-        const sliderElId = sliderEl.id;
-        // Bloom effects
-        if (sliderElId.includes("bloom")) {
-          bloomIntensity = document.getElementById("bloom-intensity").value;
-          bloomRadius = document.getElementById("bloom-radius").value;
-          bloomThreshold = document.getElementById("bloom-threshold").value;
-          if (effectBlockSectionEl.open) {
-            updateBloom(bloomIntensity, bloomRadius, bloomThreshold);
-          }
-        // Drop shadow effects
-        } else if (sliderElId.includes("shadow")) {
-          shadowLength = document.getElementById("shadow-length").value;
-          shadowDepth = document.getElementById("shadow-depth").value;
-          shadowOutline = document.getElementById("shadow-outline").value;
-          if (shadowBlockSectionEl.open) {
-            updateShadow(shadowLength, shadowDepth, shadowOutline);
-          }
-        }
-      });
-    });
-
-    // Initial layer effect
-    mapEl.addEventListener("arcgisViewChange", () => {
-      mapEl.view.ui.move("zoom", "top-right");
+  // Bloom effects
+  effectBlockSectionEl.addEventListener("calciteBlockSectionToggle", (evt) => {
+    if (evt.target.open) {
+      shadowBlockSectionEl.open = false;
       updateBloom(bloomIntensity, bloomRadius, bloomThreshold);
+    } else {
+      updateBloom(0, 0, 0);
+    }
+  });
+
+  // Drop shadow effects
+  shadowBlockSectionEl.addEventListener("calciteBlockSectionToggle", (evt) => {
+    if (evt.target.open) {
+      effectBlockSectionEl.open = false;
+      updateShadow(shadowLength, shadowDepth, shadowOutline);
+    } else {
+      updateShadow(0, 0, 0);
+    }
+  });
+
+  // Layer effect values
+  const sliderEls = document.querySelectorAll("calcite-slider");
+  sliderEls?.forEach((sliderEl) => {
+    sliderEl.addEventListener("calciteSliderInput", () => {
+      const sliderElId = sliderEl.id;
+      // Bloom effects
+      if (sliderElId.includes("bloom")) {
+        bloomIntensity = document.getElementById("bloom-intensity").value;
+        bloomRadius = document.getElementById("bloom-radius").value;
+        bloomThreshold = document.getElementById("bloom-threshold").value;
+        if (effectBlockSectionEl.open) {
+          updateBloom(bloomIntensity, bloomRadius, bloomThreshold);
+        }
+        // Drop shadow effects
+      } else if (sliderElId.includes("shadow")) {
+        shadowLength = document.getElementById("shadow-length").value;
+        shadowDepth = document.getElementById("shadow-depth").value;
+        shadowOutline = document.getElementById("shadow-outline").value;
+        if (shadowBlockSectionEl.open) {
+          updateShadow(shadowLength, shadowDepth, shadowOutline);
+        }
+      }
     });
+  });
 
-    // Bloom effect
-    function updateBloom(bloomIntensity, bloomRadius, bloomThreshold) {
-      mapEl.map.layers._items[0].effect = `bloom(${bloomIntensity}, ${bloomRadius}px, ${bloomThreshold})`;
+  // Initial layer effect
+  mapEl.addEventListener("arcgisViewChange", () => {
+    mapEl.view.ui.move("zoom", "top-right");
+    updateBloom(bloomIntensity, bloomRadius, bloomThreshold);
+  });
+
+  // Bloom effect
+  function updateBloom(bloomIntensity, bloomRadius, bloomThreshold) {
+    mapEl.map.layers._items[0].effect = `bloom(${bloomIntensity}, ${bloomRadius}px, ${bloomThreshold})`;
+  }
+
+  // Drop shadow effect
+  function updateShadow(shadowLength, shadowDepth, shadowOutline) {
+    mapEl.map.layers.items[0].effect = `drop-shadow(${shadowLength}px, ${shadowDepth}px, ${shadowOutline}px)`;
+  }
+
+  // Active action
+  const handleActionBarClick = ({ target }) => {
+    if (target.tagName !== "CALCITE-ACTION") {
+      return;
     }
 
-    // Drop shadow effect
-    function updateShadow(shadowLength, shadowDepth, shadowOutline) {
-      mapEl.map.layers.items[0].effect = `drop-shadow(${shadowLength}px, ${shadowDepth}px, ${shadowOutline}px)`;
+    if (activeWidget) {
+      activeActionEl = document.querySelector(`[data-action-id=${activeWidget}]`).removeAttribute("active");
+      activePanelEl = document.querySelector(`[data-panel-id=${activeWidget}]`).closed = true;
     }
 
-    // Active action
-    const handleActionBarClick = ({ target }) => {
-      if (target.tagName !== "CALCITE-ACTION") {
-        return;
-      }
-
-      if (activeWidget) {
-        activeActionEl = document.querySelector(`[data-action-id=${activeWidget}]`).removeAttribute("active");
-        activePanelEl = document.querySelector(`[data-panel-id=${activeWidget}]`).closed = true;
-      }
-
-      const nextWidget = target.dataset.actionId;
-      if (nextWidget !== activeWidget) {
-        document.querySelector(`[data-action-id=${nextWidget}]`).active = true;
-        document.querySelector(`[data-panel-id=${nextWidget}]`).closed = false;
-        activeWidget = nextWidget;
-        document.querySelector(`[data-panel-id=${nextWidget}]`).setFocus();
-      } else {
-        activeWidget = null;
-      }
+    const nextWidget = target.dataset.actionId;
+    if (nextWidget !== activeWidget) {
+      document.querySelector(`[data-action-id=${nextWidget}]`).active = true;
+      document.querySelector(`[data-panel-id=${nextWidget}]`).closed = false;
+      activeWidget = nextWidget;
+      document.querySelector(`[data-panel-id=${nextWidget}]`).setFocus();
+    } else {
+      activeWidget = null;
+    }
   };
 
   actionBarEl.addEventListener("click", handleActionBarClick);
@@ -239,5 +247,31 @@
     });
   }
 
-  </script>
+
+  // Handle search/popup focus 
+  const searchEl = document.querySelector("arcgis-search");
+  let abortController;
+
+
+  searchEl.addEventListener("searchComplete", onSearchComplete);
+
+  async function onSearchComplete() {
+    const reactiveUtils = await $arcgis.import("esri/core/reactiveUtils");
+
+    abortController?.abort();
+    const { signal } = (abortController = new AbortController());
+    const view = mapEl.view;
+
+    // When the popup is visible set focus on it.
+    await reactiveUtils.whenOnce(() => view.popup.visible, signal);
+    view.popup.focus();
+
+    // And when the popup is closed move the focus back to the search wiget.
+    await reactiveUtils.whenOnce(() => !view.popup.visible, signal);
+    searchEl.focusSearch();
+
+  }
+
+</script>
+
 </html>

--- a/demos/reduced-motion.html
+++ b/demos/reduced-motion.html
@@ -18,14 +18,15 @@
   <style>
     html,
     body,
-    #mapEl {
+    #viewDiv {
       padding: 0;
       margin: 0;
       height: 100%;
       width: 100%;
     }
 
-    #dateDiv {
+
+    #titleDiv {
       padding: 10px;
       box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
     }
@@ -39,37 +40,27 @@
         description="Esri Developer Summit 2024"></calcite-navigation-logo>
     </calcite-navigation>
     <calcite-panel>
-      <arcgis-map id="mapEl" portal-item="81bfc8a612d3426583fb9c93381dae84" zoom="8" basemap="gray"
-        center="-117.87574, 34.31224">
-        <arcgis-expand group="expand-widgets" position="top-left">
-          <arcgis-search></arcgis-search>
-        </arcgis-expand>
-        <arcgis-expand group="expand-widgets" position="top-left">
-          <arcgis-bookmarks visible-elements-thumbnail="false"></arcgis-bookmarks>
-        </arcgis-expand>
-        <arcgis-placement position="top-right">
-          <arcgis-legend position="top"></arcgis-legend>
-          <div id="dateDiv" class="esri-widget">
-            <p><b>Last updated</b>: <span id="date"></span></p>
-          </div>
-          <button id="worstAQI" class="esri-widget esri-button">Find the worst AQI</button>
-        </arcgis-placement>
-      </arcgis-map>
+      <div id="viewDiv"></div>
+      <div id="titleDiv" class="esri-widget">
+        <div id="legendDiv"></div>
+        <p>Last updated: <span id="date"></span></p>
+        <button id="worstAQI" class="esri-widget esri-button">Find the worst AQI</button>
+      </div>
     </calcite-panel>
   </calcite-shell>
 </body>
 
 <script>
   require([
+    "esri/WebMap",
+    "esri/views/MapView",
     "esri/layers/FeatureLayer",
     "esri/symbols/CIMSymbol",
-  ], (FeatureLayer, CIMSymbol) => {
-    // Check for reduced motion
-    const isReduced = window.matchMedia(`(prefers-reduced-motion: reduce)`) === true || window.matchMedia(`(prefers-reduced-motion: reduce)`).matches === true;
-
-    const mapEl = document.getElementById("mapEl");
-    const bookmarksEl = document.querySelector("arcgis-bookmarks");
-    let view;
+    "esri/widgets/Legend",
+    "esri/widgets/Expand",
+    "esri/widgets/Bookmarks",
+    "esri/widgets/Search"
+  ], (WebMap, MapView, FeatureLayer, CIMSymbol, Legend, Expand, Bookmarks, Search) => {
 
     // create CIMSymbol with provided rgb color
     function createCIMSymbol(r, g, b) {
@@ -82,8 +73,8 @@
             propertyName: "PlayAnimation",
             valueExpressionInfo: {
               type: "CIMExpressionInfo",
-              // Animate if the AQI is greater than 151 and animation is not reduced
-              expression: `$feature.OZONEPM_AQI_SORT >= 151 && !${isReduced}`
+              // only play the animation if AQI is greater than 151 and user does not have reduced motion
+              expression: `$feature.OZONEPM_AQI_SORT >= 151 && !${isReduced()}`
             }
           },
           {
@@ -112,8 +103,7 @@
               url: "https://upload.wikimedia.org/wikipedia/commons/f/fb/Cercle_white_blink.gif",
               animatedSymbolProperties: {
                 primitiveName: "animationOverride",
-                // Only play the animation when user does not have reduced motion
-                playAnimation: true,
+                playAnimation: !isReduced(),
                 duration: 0.75,
                 repeatType: "Loop"
               }
@@ -215,7 +205,7 @@
         minScale: 1500000,
         labelPlacement: "center-center",
         symbol: {
-          type: "text", // Autocasts as new TextSymbol()
+          type: "text", // autocasts as new TextSymbol()
           color: "black",
           font: {
             family: "Avenir Next LT Pro Medium",
@@ -272,140 +262,78 @@
       }
     });
 
-    // Add context from a live feed of smoke detection from NOAA
-    const smokeLayer = new FeatureLayer({
+
+    const map = new WebMap({
       portalItem: {
-        id: "670753899cdb49509b0225496a5b5808"
+        id: "e93e6a9ff5744e15b1c70163b3dbfc6c"
       },
-      legendEnabled: false
+      layers: [aqiLayer] // add layer to the map
     });
 
-    // Map settings
-    mapEl.addEventListener("arcgisViewChange", () => {
-      view = mapEl.view;
-      mapEl.map.constraints = { minScale: 9000000 };
-      mapEl.map.layers = [smokeLayer, aqiLayer];
-
+    const view = new MapView({
+      container: "viewDiv",
+      map,
+      popup: {
+        goToOverride: overrideGoToOptions
+      },
+      center: [-117.87, 34.31],
+      zoom: 8,
+      constraints: {
+        minScale: 9000000
+      }
     });
 
-    // Create custom bookmarks for popular U.S. cities
-    bookmarksEl.addEventListener("arcgisBookmarksReady", (evt) => {
-      evt.target.bookmarks = [
-        ({
-          name: "New York City",
-          viewpoint: {
-            targetGeometry: {
-              type: "extent",
-              spatialReference: {
-                wkid: 102100
-              },
-              xmin: -8277001.093097191,
-              xmax: -8196436.465284584,
-              ymin: 4935204.6169951,
-              ymax: 5003080.698112363
-            }
-          }
-        }),
-        ({
-          name: "Los Angeles",
-          viewpoint: {
-            targetGeometry: {
-              type: "extent",
-              spatialReference: {
-                wkid: 102100
-              },
-              xmin: -13277633.188295119,
-              xmax: -12955374.677044831,
-              ymin: 3896164.583765612,
-              ymax: 4167668.908234545
-            }
-          }
-        }),
-        ({
-          name: "Chicago",
-          viewpoint: {
-            targetGeometry: {
-              type: "extent",
-              spatialReference: {
-                wkid: 102100
-              },
-              xmin: -9828513.4088763,
-              xmax: -9667384.153251227,
-              ymin: 5069717.077609119,
-              ymax: 5205469.239843526
-            }
-          }
-        }),
-        ({
-          name: "Seattle",
-          viewpoint: {
-            targetGeometry: {
-              type: "extent",
-              spatialReference: {
-                wkid: 102100
-              },
-              xmin: -13807750.31225708,
-              xmax: -13485491.801006792,
-              ymin: 5869795.820046695,
-              ymax: 6141300.144515628
-            }
-          }
-        }),
-        ({
-          name: "Houston",
-          viewpoint: {
-            targetGeometry: {
-              type: "extent",
-              spatialReference: {
-                wkid: 102100
-              },
-              xmin: -10726402.850273041,
-              xmax: -10506569.95692479,
-              ymin: 3405510.7425089506,
-              ymax: 3540345.6604040535
-            }
-          }
-        }),
-        ({
-          name: "Phoenix",
-          viewpoint: {
-            targetGeometry: {
-              type: "extent",
-              spatialReference: {
-                wkid: 102100
-              },
-              xmin: -12586137.43292289,
-              xmax: -12366304.53957464,
-              ymin: 3887587.260435651,
-              ymax: 4022422.178330754
-            }
-          }
+    const legend = new Legend({
+      view,
+      container: "legendDiv"
+    });
+    view.ui.add("titleDiv", "top-right");
+
+    view.ui.add(new Expand({
+      view,
+      group: "left",
+      content: new Bookmarks({ view, visibleElements: { thumbnail: false }, goToOverride: overrideGoToOptions })
+    }), "top-left");
+
+    view.ui.add(new Expand({
+      view,
+      group: "left",
+      content: new Search({ view, goToOverride: overrideGoToOptions })
+    }), "top-left");
+
+    view.whenLayerView(aqiLayer).then((aqiLayerView) => {
+      document.getElementById("date").innerHTML = aqiLayer.editingInfo.lastEditDate.toLocaleString();
+      const worstBtn = document.getElementById("worstAQI");
+      worstBtn.addEventListener("click", () => {
+        // query for the highest AQI and navigate the user to that feature
+        const query = {
+          where: "1=1",
+          orderByFields: ["OZONEPM_AQI_SORT DESC"],
+          outFields: ["OZONEPM_AQI_SORT"],
+          num: 1,
+          returnGeometry: true
+        };
+        aqiLayerView.queryFeatures(query).then((results) => {
+
+          const worst = results.features[0];
+          if (worst) view.goTo(worst, { animate: !isReduced() });
         })
-      ];
+      })
     });
+    function isReduced() {
+      return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    }
 
-    // Update the date when the layer view is created
-    mapEl.addEventListener("arcgisViewLayerviewCreate", () => {
-      view.whenLayerView(aqiLayer).then((aqiLayerView) => {
-        document.getElementById("date").innerHTML = aqiLayer.editingInfo.lastEditDate.toLocaleString();
-        const worstBtn = document.getElementById("worstAQI");
-        worstBtn.addEventListener("click", () => {
-          // Query for the highest AQI and navigate the user to the feature
-          const query = {
-            where: "1=1",
-            orderByFields: ["OZONEPM_AQI_SORT DESC"],
-            outFields: ["OZONEPM_AQI_SORT"],
-            num: 1,
-            returnGeometry: true
-          };
-          aqiLayerView.queryFeatures(query).then((results) => {
-            const worstAirResult = results.features[0];
-            view.goTo(worstAirResult);
-          });
-        });
+    function overrideGoToOptions(view, goToParams) {
+
+      const { target, options } = goToParams;
+
+      return view.goTo(target, {
+        ...options,
+        animate: !isReduced(),
       });
-    });
 
+    }
   });
 </script>
 


### PR DESCRIPTION
- Add goToOverride support to disable animation for bookmarks, search, popup when prefersReducedMotion is enabled. -- Moved bookmarks logic to web map to reduce amount of code in sample.
- Updated focus sample to add search/popup focus logic. I can move this to a separate sample if you think that makes more sense?